### PR TITLE
package imports in module headers

### DIFF
--- a/ivltests/mod_inst_pkg.v
+++ b/ivltests/mod_inst_pkg.v
@@ -1,0 +1,67 @@
+package fooPkg;
+    localparam FOO = 5;
+endpackage
+
+package barPkg;
+    function int get_size (
+        input int x
+    );
+        return x + 3;
+    endfunction
+endpackage
+
+package bazPkg;
+    typedef int baz;
+endpackage
+
+/*
+IEEE 1800-2012 A.1.2 says:
+
+module_nonansi_header ::=
+  { attribute_instance } module_keyword [ lifetime ] module_identifier
+    { package_import_declaration } [ parameter_port_list ] list_of_ports ;
+module_ansi_header ::=
+  { attribute_instance } module_keyword [ lifetime ] module_identifier
+    { package_import_declaration } [ parameter_port_list ] [ list_of_port_declarations ] ;
+
+This allows for the importing of packages during module definition which can be used in the
+  parameter and port lists.
+*/
+
+module foo
+// Testing comman separated imports
+import
+    fooPkg::*,
+    barPkg::*;
+// Testing multiple import statements
+import bazPkg::*;
+#(
+    parameter FOO_PARAM = FOO
+)
+(
+    input [get_size(7)-1:0] inport
+);
+
+    baz value = 11;
+
+    initial begin
+        if ($bits(inport) != 10) begin
+            $display("FAILED -- function import in module declaration failed (%d)", $bits(inport));
+            $finish;
+        end
+
+        if (value != 11) begin
+            $display("FAILED -- Something is wrong with typedef import (%d)", value);
+            $finish;
+        end
+
+        if (FOO_PARAM != 5) begin
+            $display("FAILED -- Something is wrong with paramater imports (%d)", FOO_PARAM);
+            $finish;
+        end
+
+        $display("PASSED");
+        $finish;
+    end
+
+endmodule

--- a/regress.list
+++ b/regress.list
@@ -5061,3 +5061,4 @@ sv_uwire3	normal,-g2009	ivltests
 sv_uwire4	normal,-g2009	ivltests
 synth_if_no_else normal,-S	ivltests
 arith-unknown	normal	ivltests
+mod_inst_pkg    normal,-g2009	ivltests


### PR DESCRIPTION
Test confirms support for package imports in module headers
Regressing before / after shows this change didn't break anything

```
$ diff before.log after.log 
2008c2008
<                mod_inst_pkg: ==> Failed - running iverilog.

---
>                mod_inst_pkg: Passed.
2011c2011
<   Total=2006, Passed=1999, Failed=7, Not Implemented=0, Expected Fail=0

---
>   Total=2006, Passed=2000, Failed=6, Not Implemented=0, Expected Fail=0
```
