### PR TITLE
Removed all mentions of hardcoded perl path

### DIFF
--- a/obsolete/eregress.pl
+++ b/obsolete/eregress.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -s
+#!/usr/bin/env perl -s
 #
 # Copyright (c) 1999 Guy Hutchison (stevew@home.com)
 #

--- a/obsolete/sregress.pl
+++ b/obsolete/sregress.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -s
+#!/usr/bin/env perl -s
 ##!/utilities/perl/bin/perl -s
 #
 # Copyright (c) 1999 Guy Hutchison (ghutchis@pacbell.net)

--- a/obsolete/vvptests/vvp.pl
+++ b/obsolete/vvptests/vvp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -s
+#!/usr/bin/env perl -s
 ##!/utilities/perl/bin/perl -s
 #
 # Script vvp.pl modified to handle vvp for Steve Williams
@@ -62,7 +62,7 @@ $comp_name = "IVL" ;	# Change the name of the compiler in use here.
                         # this may change to a command line option after
 			# I get things debugged!
 
-   $vername = "/usr/local/bin/vvp";	    # IVL's shell
+   $vername = "/usr/bin/env vvp";	    # IVL's shell
    $versw   = "";			    # switches
    $verout  = "-o simv -tvvp";	# vvp source output (for IVL )
    #$redir = "&>";
@@ -235,7 +235,7 @@ sub execute_regression {
 	#           !($testtype{$testname} eq "CN" ) &&
 	#           !($testtype{$testname} eq "CE" )) {
 	#          system ("rm -rf core");
-	#          system ("/usr/local/bin/vvp simv >> $lpath 2>&1 ");
+	#          system ("/usr/bin/env vvp simv >> $lpath 2>&1 ");
 	#        } else {
 	#
 	#        }

--- a/obsolete/vvptests/vvpsources/force.vp
+++ b/obsolete/vvptests/vvpsources/force.vp
@@ -1,4 +1,4 @@
-#! /usr/local/bin/vvp -v
+#! /usr/bin/env vvp -v
 :vpi_time_precision + 0;
 :vpi_module "system";
 S_test .scope module, "test";

--- a/obsolete/vvptests/vvpsources/hello.vp
+++ b/obsolete/vvptests/vvpsources/hello.vp
@@ -1,4 +1,4 @@
-#! /usr/local/lib/ivl/../../bin/vvp
+#! /usr/bin/env vvp
 :vpi_module "system";
 S_main .scope module, "main";
     .scope S_main;

--- a/vhdl_reg.pl
+++ b/vhdl_reg.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Regression script for VHDL output. Based on vvp_reg.pl.
 #

--- a/vlog95_reg.pl
+++ b/vlog95_reg.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to handle regression for normal Verilog files.
 #

--- a/vpi_reg.pl
+++ b/vpi_reg.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to handle regression for VPI routines
 #

--- a/vvp_reg.pl
+++ b/vvp_reg.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Script to handle regression for Icarus Verilog using the vvp target.
 #


### PR DESCRIPTION
I ran your testsuite on NetBSD before importing iverilog to pkgsrc in order to confirm the package is working correctly. Almost all OK.

I've removed some hard-coded paths of perl (replacing them with /usr/bin/env perl).
You may benefit from it if you choose to run it on other operating systems.

Thank you for iverilog.