### PR TITLE
Add tests for priority and unique case qualifiers.

### DIFF
--- a/gold/case_priority.gold
+++ b/gold/case_priority.gold
@@ -1,0 +1,6 @@
+case 0
+case 1
+WARNING: ./ivltests/case_priority.v:12: value is unhandled for priority or unique case statement
+         Time: 50000 Scope: main
+case 3
+PASSED

--- a/gold/case_unique.gold
+++ b/gold/case_unique.gold
@@ -1,0 +1,7 @@
+./ivltests/case_unique.v:12: tgt-vvp sorry: Case unique/unique0 qualities are ignored.
+case 0
+case 1
+WARNING: ./ivltests/case_unique.v:12: value is unhandled for priority or unique case statement
+         Time: 50000 Scope: main
+case 3
+PASSED

--- a/ivltests/case_priority.v
+++ b/ivltests/case_priority.v
@@ -1,0 +1,23 @@
+`timescale 10ns/1ps
+
+module main;
+   logic [1:0] counter = 2'b00;
+   logic       clk = 1'b0;
+
+   initial forever #1 clk <= ~clk;
+
+   always @(posedge clk) begin
+      counter <= counter + 2'd1;
+      
+      priority case (counter)
+      2'd0: $display("case 0");
+      2'd1: $display("case 1");
+      2'd3: $display("case 3");
+      endcase // priority case (counter)
+
+      if (counter == 2'd3) begin
+         $display("PASSED");
+         $finish;
+      end
+   end
+endmodule

--- a/ivltests/case_unique.v
+++ b/ivltests/case_unique.v
@@ -1,0 +1,23 @@
+`timescale 10ns/1ps
+
+module main;
+   logic [1:0] counter = 2'b00;
+   logic       clk = 1'b0;
+
+   initial forever #1 clk <= ~clk;
+
+   always @(posedge clk) begin
+      counter <= counter + 2'd1;
+      
+      unique case (counter)
+      2'd0: $display("case 0");
+      2'd1: $display("case 1");
+      2'd3: $display("case 3");
+      endcase // priority case (counter)
+
+      if (counter == 2'd3) begin
+         $display("PASSED");
+         $finish;
+      end
+   end
+endmodule

--- a/regress-sv.list
+++ b/regress-sv.list
@@ -172,6 +172,8 @@ br_ml20181012a		CE,-g2009		ivltests
 br_ml20181012b		CE,-g2009		ivltests
 br_ml20181012c		CE,-g2009		ivltests
 br_ml20181012d		CE,-g2009		ivltests
+case_priority           normal,-g2005-sv        ivltests gold=case_priority.gold
+case_unique             normal,-g2005-sv        ivltests gold=case_unique.gold
 cast_real		normal,-g2005-sv	ivltests
 cfunc_assign_op_mixed	normal,-g2009		ivltests
 cfunc_assign_op_pv	normal,-g2009		ivltests


### PR DESCRIPTION
Test cases for priority and unique case qualifiers (nb: unique case should presumbably also warn because of the non-unique condition, if that was checked for).