### PR TITLE
Potential lint fixes for tests

### DIFF
--- a/ivltests/idiv1.v
+++ b/ivltests/idiv1.v
@@ -86,7 +86,7 @@ initial begin
          $display("FAILED - Divide x/3 reg assign failed - is %b",result);
          $finish;
       end
-   if( wresult !== 8'hxxxx_xxxx)
+   if( wresult !== 8'bxxxx_xxxx)
      begin
         $display("FAILED - Divide x/3 wire assign failed - is %b",wresult);
         $finish;

--- a/ivltests/mixed_type_div_mod.v
+++ b/ivltests/mixed_type_div_mod.v
@@ -21,14 +21,14 @@ module top;
     // This should turn into a just a load of 1.0.
     result = 1%2.0;
     if (result != 1.0) begin
-      $display("Failed: int%real, expected 1.0, got %g", result);
+      $display("Failed: int%%real, expected 1.0, got %g", result);
       pass = 1'b0;
     end
 
     // This should turn into a just a load of 1.0.
     result = 1.0%2;
     if (result != 1.0) begin
-      $display("Failed: real%int, expected 1.0, got %g", result);
+      $display("Failed: real%%int, expected 1.0, got %g", result);
       pass = 1'b0;
     end
 

--- a/ivltests/pr1695322.v
+++ b/ivltests/pr1695322.v
@@ -10,7 +10,7 @@ module test ();
 	 $finish;
       end
 
-      if (a[1] !== 6'bzzzzzzzz) begin
+      if (a[1] !== 6'bzzzzzz) begin
 	 $display("FAILED -- a[1] == %h", a[1]);
 	 $finish;
       end

--- a/ivltests/pr2123190.v
+++ b/ivltests/pr2123190.v
@@ -13,7 +13,7 @@ module top;
       end
       rin = 2.0;
       #1 if (ress != 4.0 || reso != 3.0) begin
-	 $display("FAILED: rin=%f, scale=%f, expected 2.0/2.0, got %f/%f", ress, reso);
+	 $display("FAILED: rin=%f, scale=%f, expected 2.0/2.0, got %f/%f", rin, scale, ress, reso);
 	 pass = 1'b0;
       end
 

--- a/ivltests/sv_darray1.v
+++ b/ivltests/sv_darray1.v
@@ -36,7 +36,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end

--- a/ivltests/sv_darray2.v
+++ b/ivltests/sv_darray2.v
@@ -37,7 +37,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end

--- a/ivltests/sv_darray3.v
+++ b/ivltests/sv_darray3.v
@@ -37,7 +37,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end

--- a/ivltests/sv_darray4.v
+++ b/ivltests/sv_darray4.v
@@ -37,7 +37,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end

--- a/ivltests/sv_darray5.v
+++ b/ivltests/sv_darray5.v
@@ -37,7 +37,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end

--- a/ivltests/sv_darray5b.v
+++ b/ivltests/sv_darray5b.v
@@ -37,7 +37,7 @@ module main;
 
       for (idx = 0 ; idx < 2*foo.size() ; idx += 1) begin
 	 if (foo[idx%10] != (idx%10)) begin
-	    $display("FAILED -- foo[%0d%%10] = %0d", foo[idx%10]);
+	    $display("FAILED -- foo[%0d%%10] = %0d", idx, foo[idx%10]);
 	    $finish;
 	 end
       end


### PR DESCRIPTION
This pull fixes some lint issues with several tests.  I'm doing this because before these changes tests failed on Verilator, as it generally assumes things like format errors are serious enough to avoid compilation.  (Many tests still fail for many other reasons, but these were the easy ones that seemed to be false failures.)

I think these are good cleanups and don't believe they interfere with the intent of the tests. However I understand if you don't want to take these.  Thanks for the consideration.
