### PR TITLE
Add regression test for logical operator short-circuiting

### DIFF
--- a/ivltests/logical_short_circuit.v
+++ b/ivltests/logical_short_circuit.v
@@ -1,0 +1,147 @@
+module test;
+
+// The SystemVerilog standard requires that the right side of a logical operator
+// is not evaluated under certain conditions.
+//  For && if the left hand side is false the right hand side is not evalualted
+//  For || if the left hand side is true the right hand side is not evalualted
+
+wire a0 = 1'b0;
+wire a1 = 1'b1;
+wire ax = 1'bx;
+wire az = 1'bz;
+
+integer b;
+logic [1:0] c;
+
+bit failed = 1'b0;
+
+initial begin
+  // AND with first parameter 1'b0
+  b = 0;
+  c = 2'b00;
+
+  if (a0 && b++ && ++b)
+    c = 2'b01;
+
+  failed |= b !== 0;
+  failed |= c !== 2'b00;
+
+  c = a0 && b++ && ++b;
+
+  failed |= b !== 0;
+  failed |= c !== 2'b00;
+
+  // AND with first parameter 1'b1
+  b = 0;
+  c = 2'b00;
+
+  if (a1 && b++ && ++b)
+    c = 2'b01;
+
+  failed |= b !== 1;
+  failed |= c !== 2'b00;
+
+  c = a1 && b++ && ++b;
+
+  failed |= b !== 3;
+  failed |= c !== 2'b01;
+
+  // AND with first parameter 1'bz
+  b = 0;
+  c = 2'b00;
+
+  if (az && b++ && ++b)
+    c = 2'b01;
+
+  failed |= b !== 1;
+  failed |= c !== 2'b00;
+
+  c = az && b++ && ++b;
+
+  failed |= b !== 3;
+  failed |= c !== 2'b0x;
+
+  // AND with first parameter 1'bz
+  b = 0;
+  c = 0;
+
+  if (ax && b++ && ++b)
+    c = 2'b01;
+
+  failed |= b !== 1;
+  failed |= c !== 2'b00;
+
+  c = ax && b++ && ++b;
+
+  failed |= b !== 3;
+  failed |= c !== 2'b0x;
+
+  // OR with first parameter 1'b0
+  b = 0;
+  c = 0;
+
+  if (a0 || b++ || ++b)
+    c = 2'b01;
+
+  failed |= b !== 2;
+  failed |= c !== 2'b01;
+
+  c = a0 || b++ || ++b;
+
+  failed |= b !== 3;
+  failed |= c !== 2'b01;
+
+  // OR with first parameter 1'b1
+  b = 0;
+  c = 2'b00;
+
+  if (a1 || b++ || ++b)
+    c = 2'b01;
+
+  failed |= b !== 0;
+  failed |= c !== 2'b01;
+
+  c = a1 || b++ || ++b;
+
+  failed |= b !== 0;
+  failed |= c !== 2'b01;
+
+  // OR with first parameter 1'bz
+  b = 0;
+  c = 2'b00;
+
+  if (az || b++ || ++b)
+    c = 2'b01;
+
+  failed |= b !== 2;
+  failed |= c !== 2'b01;
+
+  b = 0;
+  c = az || b++;
+
+  failed |= b !== 1;
+  failed |= c !== 2'b0x;
+
+  // OR with first parameter 1'bz
+  b = 0;
+  c = 0;
+
+  if (ax || b++ || ++b)
+    c = 2'b01;
+
+  failed |= b !== 2;
+  failed |= c !== 2'b01;
+
+  b = 0;
+  c = ax || b++;
+
+  failed |= b !== 1;
+  failed |= c !== 2'b0x;
+
+  if (failed)
+    $display("FAILED");
+  else
+    $display("PASSED");
+end
+
+endmodule

--- a/regress-sv.list
+++ b/regress-sv.list
@@ -293,6 +293,7 @@ l_equiv_const		normal,-g2005-sv	ivltests
 line_directive		normal,-g2009,-I./ivltests	ivltests gold=line_directive.gold
 localparam_query	normal,-g2005-sv	ivltests
 localparam_type2	normal,-g2009		ivltests
+logical_short_circuit	normal,-g2012		ivltests
 logp2			normal,-g2005-sv	ivltests
 mod_inst_pkg		normal,-g2009		ivltests
 named_begin		normal,-g2009		ivltests

--- a/regress-vlog95.list
+++ b/regress-vlog95.list
@@ -411,6 +411,7 @@ enum_test1		CE,-g2009		ivltests  # enum
 fork_join_any		CE,-g2009,-pallowsigned=1	ivltests  # join_any
 fork_join_dis		CE,-g2009,-pallowsigned=1	ivltests  # join_any
 fork_join_none		CE,-g2009,-pallowsigned=1	ivltests  # join_none
+logical_short_circuit	CE,-g2012		ivltests # ++
 plus_5			CE,-g2009,-pallowsigned=1	ivltests  # ++/--
 pr3366217f		CE,-g2009,-pallowsigned=1	ivltests  # enum
 pr3366217h		CE,-g2009,-pallowsigned=1	ivltests  # enum

--- a/regression_report-devel.txt
+++ b/regression_report-devel.txt
@@ -2068,6 +2068,7 @@ test_mos_strength_reduction: Passed.
              line_directive: Passed.
            localparam_query: Passed.
            localparam_type2: Passed.
+      logical_short_circuit: Passed.
                       logp2: Passed.
                mod_inst_pkg: Passed.
                 named_begin: Passed.
@@ -2556,4 +2557,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2554, Passed=2548, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2555, Passed=2549, Failed=3, Not Implemented=0, Expected Fail=3

--- a/regression_report-fsv.txt
+++ b/regression_report-fsv.txt
@@ -2075,6 +2075,7 @@ test_mos_strength_reduction: Passed.
              line_directive: Passed.
            localparam_query: Passed.
            localparam_type2: Passed.
+      logical_short_circuit: Passed.
                       logp2: Passed.
                mod_inst_pkg: Passed.
                 named_begin: Passed.
@@ -2556,4 +2557,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2554, Passed=2534, Failed=17, Not Implemented=3, Expected Fail=0
+  Total=2555, Passed=2535, Failed=17, Not Implemented=3, Expected Fail=0

--- a/regression_report-strict.txt
+++ b/regression_report-strict.txt
@@ -2064,6 +2064,7 @@ test_mos_strength_reduction: Passed.
              line_directive: Passed.
            localparam_query: Passed.
            localparam_type2: Passed.
+      logical_short_circuit: Passed.
                       logp2: Passed.
                mod_inst_pkg: Passed.
                 named_begin: Passed.
@@ -2553,4 +2554,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2551, Passed=2545, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2552, Passed=2546, Failed=3, Not Implemented=0, Expected Fail=3

--- a/regression_report-vlog95.txt
+++ b/regression_report-vlog95.txt
@@ -310,6 +310,7 @@ Running vlog95 compiler/VVP tests for Icarus Verilog version: 12.
               fork_join_any: Passed - CE.
               fork_join_dis: Passed - CE.
              fork_join_none: Passed - CE.
+      logical_short_circuit: Passed - CE.
                      plus_5: Passed - CE.
                  pr3366217f: Passed - CE.
                  pr3366217h: Passed - CE.
@@ -2556,4 +2557,4 @@ test_mos_strength_reduction: Passed.
            synth_if_no_else: Passed.
 ============================================================================
 Test results:
-  Total=2554, Passed=2515, Failed=2, Not Implemented=3, Expected Fail=34
+  Total=2555, Passed=2516, Failed=2, Not Implemented=3, Expected Fail=34


### PR DESCRIPTION
SystemVerilog requires that the right-hand side of a logical operator is
not evaluated if the result can be determined after evaluating the
left-hand side. More specifically that means the right-hand side is not
evaluated
 * if the left-hand side of a && operator is logically false
 * if the left-hand side of a || operator is logically true

Add a regression test that checks correct behavior for logical operator
short-circuiting.

For this test to pass https://github.com/steveicarus/iverilog/pull/573 has to be merged