### PR TITLE
Add a regression test for invalid enum dimensions

### DIFF
--- a/gold/enum_dims_invalid.gold
+++ b/gold/enum_dims_invalid.gold
@@ -1,0 +1,8 @@
+ivltests/enum_dims_invalid.v:13: error: An unsized dimension is not allowed here.
+ivltests/enum_dims_invalid.v:17: error: Dimension size must be greater than zero.
+ivltests/enum_dims_invalid.v:17       : This size expression violates the rule: -('sd1)
+ivltests/enum_dims_invalid.v:9: error: A queue dimension is not allowed here.
+ivltests/enum_dims_invalid.v:21: error: Dimension size must be greater than zero.
+ivltests/enum_dims_invalid.v:21       : This size expression violates the rule: 'sd0
+ivltests/enum_dims_invalid.v:25: error: Enum type must not have more than 1 packed dimension.
+6 error(s) during elaboration.

--- a/ivltests/enum_dims_invalid.v
+++ b/ivltests/enum_dims_invalid.v
@@ -1,0 +1,50 @@
+// Check that all sorts of enum dimension declarations are handled correctly and
+// do not cause an assert or segfault.
+
+module test;
+
+// These are invalid
+
+enum logic [$] {
+	A
+} a;
+
+enum logic [] {
+  B
+} b;
+
+enum logic [-1] {
+	C
+} c;
+
+enum logic [0] {
+	D
+} d;
+
+enum logic [1:0][3:0] {
+	E
+} e;
+
+// These are valid
+
+enum logic [0:2] {
+	F
+} f;
+
+enum logic [2:0] {
+	G
+} g;
+
+enum logic [-1:-2] {
+	H
+} h;
+
+// These are valid as an extension in iverilog
+
+enum logic [16] {
+	I
+} i;
+
+int x;
+
+endmodule

--- a/regress-sv.list
+++ b/regress-sv.list
@@ -230,6 +230,7 @@ display_bug		normal,-g2009		ivltests gold=display_bug.gold
 edge			normal,-g2009		ivltests
 enum_base_range		normal,-g2005-sv	ivltests
 enum_elem_ranges	normal,-g2005-sv	ivltests
+enum_dims_invalid	CE,-g2005-sv		ivltests
 enum_next		normal,-g2005-sv	ivltests
 enum_ports		normal,-g2005-sv	ivltests
 enum_test1		normal,-g2005-sv	ivltests

--- a/regression_report-devel.txt
+++ b/regression_report-devel.txt
@@ -2005,6 +2005,7 @@ test_mos_strength_reduction: Passed.
                        edge: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
+          enum_dims_invalid: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2560,4 +2561,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2558, Passed=2552, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2559, Passed=2553, Failed=3, Not Implemented=0, Expected Fail=3

--- a/regression_report-fsv.txt
+++ b/regression_report-fsv.txt
@@ -2012,6 +2012,7 @@ test_mos_strength_reduction: Passed.
                        edge: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
+          enum_dims_invalid: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2560,4 +2561,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2558, Passed=2538, Failed=17, Not Implemented=3, Expected Fail=0
+  Total=2559, Passed=2539, Failed=17, Not Implemented=3, Expected Fail=0

--- a/regression_report-strict.txt
+++ b/regression_report-strict.txt
@@ -2001,6 +2001,7 @@ test_mos_strength_reduction: Passed.
                        edge: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
+          enum_dims_invalid: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2557,4 +2558,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2555, Passed=2549, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2556, Passed=2550, Failed=3, Not Implemented=0, Expected Fail=3

--- a/regression_report-vlog95.txt
+++ b/regression_report-vlog95.txt
@@ -2308,6 +2308,7 @@ test_mos_strength_reduction: Passed.
                 display_bug: Passed.
                        edge: Passed.
             enum_base_range: Passed.
+          enum_dims_invalid: Passed - CE.
                  enum_test2: Passed.
                  enum_test3: Passed - CE.
                  enum_test4: Passed.
@@ -2560,4 +2561,4 @@ test_mos_strength_reduction: Passed.
            synth_if_no_else: Passed.
 ============================================================================
 Test results:
-  Total=2558, Passed=2519, Failed=2, Not Implemented=3, Expected Fail=34
+  Total=2559, Passed=2520, Failed=2, Not Implemented=3, Expected Fail=34


### PR DESCRIPTION
Add a regression test that checks that invalid enum dimensions are detected
and an elaboration error is reported rather than crashing the application.

This is the regression test for https://github.com/steveicarus/iverilog/pull/578.