### PR TITLE
Fix file module order for sv-test runner.

### DIFF
--- a/ivltests/br_gh104b.v
+++ b/ivltests/br_gh104b.v
@@ -2,6 +2,14 @@ task start;
   top.dut.signal = 1;
 endtask
 
+module top();
+  initial begin
+    #1 start();
+  end
+
+  dut dut();
+endmodule
+
 module dut();
   logic signal = 0;
 
@@ -15,12 +23,4 @@ module dut();
       $display("FAILED");
     $finish;
   end
-endmodule
-
-module top();
-  initial begin
-    #1 start();
-  end
-
-  dut dut();
 endmodule

--- a/ivltests/def_nettype_none.v
+++ b/ivltests/def_nettype_none.v
@@ -4,11 +4,6 @@
  * generated."
  */
 
-module ok;
-reg a;
-assign b=a;
-endmodule
-
 `default_nettype none
 
 module bad;

--- a/ivltests/implicit-port2.v
+++ b/ivltests/implicit-port2.v
@@ -1,10 +1,10 @@
 // test that if the signal doesn't exist, an error is thrown
-module m(input a, output b);
-assign b = a;
-endmodule
-
 module top;
 reg a;
 // wire b;
 m foo(.a, .b);
+endmodule
+
+module m(input a, output b);
+assign b = a;
 endmodule

--- a/ivltests/implicit-port3.v
+++ b/ivltests/implicit-port3.v
@@ -1,11 +1,11 @@
 // test that if the port doesn't exist, an error is thrown
-module m(input a, output b);
-assign b = a;
-endmodule
-
 module top;
 reg a;
 wire b;
 wire c;
 m foo(.a, .b, .c);
+endmodule
+
+module m(input a, output b);
+assign b = a;
 endmodule

--- a/ivltests/implicit-port6.v
+++ b/ivltests/implicit-port6.v
@@ -1,10 +1,10 @@
 // test that if the signal doesn't exist, an error is thrown
-module m(input a, output b);
-assign b = a;
-endmodule
-
 module top;
 reg a;
 // wire b;
 m foo(.*);
+endmodule
+
+module m(input a, output b);
+assign b = a;
 endmodule

--- a/ivltests/mhead_task.v
+++ b/ivltests/mhead_task.v
@@ -18,14 +18,6 @@
 //
 //  SDW - Validate fork template 2
 
-module main;
-
-   initial begin
-      other_main.passed;
-   end
-
-endmodule // main
-
 module other_main;
 
    task passed;
@@ -33,3 +25,11 @@ module other_main;
    endtask // passed
 
 endmodule
+
+module main;
+
+   initial begin
+      other_main.passed;
+   end
+
+endmodule // main

--- a/ivltests/pr1698659.v
+++ b/ivltests/pr1698659.v
@@ -1,5 +1,12 @@
 `timescale 1ns/10ps
 
+module othertop;
+  reg othertopvar;
+  initial begin
+    #20 $display("%m var is (%b)", othertopvar);
+  end
+endmodule
+
 module top;
   reg topvar;
   initial begin
@@ -28,12 +35,5 @@ module evenlower;
     $display("Up reference to me (%b)", elwr.evenlowervar);
     $display("Up reference to parent (%b)", lwr.lowervar);
     $display("Up reference is (%b)", lower.lowervar);
-  end
-endmodule
-
-module othertop;
-  reg othertopvar;
-  initial begin
-    #20 $display("%m var is (%b)", othertopvar);
   end
 endmodule

--- a/ivltests/pr2076425.v
+++ b/ivltests/pr2076425.v
@@ -1,3 +1,9 @@
+module z;
+  task delay;
+    #1;
+  endtask
+endmodule
+
 module top;
 
   task delay;
@@ -12,10 +18,4 @@ module top;
     #10 $display("PASSED");
     $finish;
   end
-endmodule
-
-module z;
-  task delay;
-    #1;
-  endtask
 endmodule

--- a/ivltests/shellho1.v
+++ b/ivltests/shellho1.v
@@ -32,6 +32,14 @@
 ***************************************************************************/
 
 
+// Module to instantiate test and memory modules
+module top;
+
+ bug_test bug_test();
+ memory memory();
+
+endmodule
+
 module bug_test;
 
 reg [1:0] temp;
@@ -95,13 +103,5 @@ endmodule
 module memory;
 
 reg [3:0] memory [0:1];
-
-endmodule
-
-// Module to instantiate test and memory modules
-module top;
-
- bug_test bug_test();
- memory memory();
 
 endmodule


### PR DESCRIPTION
This pull changes the order of some modules in the following test files:
* ivltests/br_gh104b.v
* ivltests/def_nettype_none.v
* ivltests/implicit-port2.v
* ivltests/implicit-port3.v
* ivltests/implicit-port6.v
* ivltests/mhead_task.v
* ivltests/pr1698659.v
* ivltests/pr2076425.v
* ivltests/shellho1.v

The sv-tests (https://github.com/chipsalliance/sv-tests) runner script simply looks for the first module in a file, and specifies that as the top-module to other tools.  Doing so breaks these tests, as they were not written with that assumption.

It appears to me that changing the order of modules in the above files does not affect the intent of the tests, therefore I suggest this pull request be merged.  That will allow the tests to still serve a good purpose against other simulators/tools. If there's some reason you'd prefer not to take some or all of these, I can alternatively blacklist the tests in sv-tests.  Thanks.